### PR TITLE
add python interface base class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclpy REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
 
@@ -70,6 +71,8 @@ install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION include/${PROJECT_NAME}
 )
 
+ament_python_install_package(${PROJECT_NAME})
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
@@ -78,3 +81,4 @@ endif()
 ament_export_targets("export_buoy_interface")
 
 ament_package()
+

--- a/buoy_msgs/interface.py
+++ b/buoy_msgs/interface.py
@@ -1,0 +1,236 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc. and Monterey Bay Aquarium Research Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import rclpy
+from rclpy.node import Node
+
+# pbsrv commands
+# power microcontroller
+from buoy_msgs.srv import PCBattSwitchCommand
+from buoy_msgs.srv import PCBiasCurrCommand
+from buoy_msgs.srv import PCChargeCurrLimCommand
+from buoy_msgs.srv import PCDrawCurrLimCommand
+from buoy_msgs.srv import PCPackRateCommand
+from buoy_msgs.srv import PCRetractCommand
+from buoy_msgs.srv import PCScaleCommand
+from buoy_msgs.srv import PCStdDevTargCommand
+from buoy_msgs.srv import PCVTargMaxCommand
+from buoy_msgs.srv import PCWindCurrCommand
+from buoy_msgs.srv import GainCommand
+
+# battery microcontroller
+from buoy_msgs.srv import BCResetCommand
+
+# spring microcontroller
+from buoy_msgs.srv import SCPackRateCommand
+from buoy_msgs.srv import SCResetCommand
+from buoy_msgs.srv import ValveCommand
+from buoy_msgs.srv import PumpCommand
+from buoy_msgs.srv import BenderCommand
+from buoy_msgs.srv import TetherCommand
+
+# trefoil microcontroller
+from buoy_msgs.srv import TFResetCommand
+from buoy_msgs.srv import TFSetActualPosCommand
+from buoy_msgs.srv import TFSetChargeModeCommand
+from buoy_msgs.srv import TFSetCurrLimCommand
+from buoy_msgs.srv import TFSetModeCommand
+from buoy_msgs.srv import TFSetPosCommand
+from buoy_msgs.srv import TFSetStateMachineCommand
+from buoy_msgs.srv import TFWatchDogCommand
+
+
+# pb telemetry
+from buoy_msgs.msg import XBRecord  # ahrs
+from buoy_msgs.msg import BCRecord  # battery
+from buoy_msgs.msg import SCRecord  # spring
+from buoy_msgs.msg import PCRecord  # power
+from buoy_msgs.msg import TFRecord  # trefoil
+from buoy_msgs.msg import PBRecord  # consolidated
+
+
+pbsrv_enum2str = {0: "OK",
+                  -1: "BAD_SOCK",
+                  -2: "BAD_OPTS",
+                  -3: "BAD_INPUT"}
+
+
+class Interface(Node):
+    def __init__(self, node_name):
+        super().__init__(node_name)
+        self.pc_pack_rate_client_ = self.create_client(PCPackRateCommand, "/pc_pack_rate_command")
+        self.pc_wind_curr_client_ = self.create_client(PCWindCurrCommand, "/pc_wind_curr_command")
+        self.bender_client_ = self.create_client(BenderCommand, "/bender_command")
+        self.bc_reset_client_ = self.create_client(BCResetCommand, "/bc_reset_command")
+        self.pump_client_ = self.create_client(PumpCommand, "/pump_command")
+        self.valve_client_ = self.create_client(ValveCommand, "/valve_command")
+        self.tether_client_ = self.create_client(TetherCommand, "/tether_command")
+        self.sc_reset_client_ = self.create_client(SCResetCommand, "/sc_reset_command")
+        self.sc_pack_rate_client_ = self.create_client(SCPackRateCommand, "/sc_pack_rate_command")
+        self.pc_scale_client_ = self.create_client(PCScaleCommand, "/fake_pc_scale_command")
+        self.pc_retract_client_ = self.create_client(PCRetractCommand, "/pc_retract_command")
+        self.pc_v_targ_max_client_ = self.create_client(PCVTargMaxCommand,
+                                                        "/pc_v_targ_max_command")
+        self.pc_charge_curr_lim_client_ = self.create_client(PCChargeCurrLimCommand,
+                                                             "/pc_charge_curr_lim_command")
+        self.pc_batt_switch_client_ = self.create_client(PCBattSwitchCommand,
+                                                         "/pc_batt_switch_command")
+        self.gain_client_ = self.create_client(GainCommand, "/gain_command")
+        self.pc_std_dev_targ_client_ = self.create_client(PCStdDevTargCommand,
+                                                          "/pc_std_dev_targ_command")
+        self.pc_draw_curr_lim_client_ = self.create_client(PCDrawCurrLimCommand,
+                                                           "/pc_draw_curr_lim_command")
+        self.pc_bias_curr_client_ = self.create_client(PCBiasCurrCommand, "/pc_bias_curr_command")
+        self.tf_set_pos_client_ = self.create_client(TFSetPosCommand, "/tf_set_pos_command")
+        self.tf_set_actual_pos_client_ = self.create_client(TFSetActualPosCommand,
+                                                            "/tf_set_actual_pos_command")
+        self.tf_set_mode_client_ = self.create_client(TFSetModeCommand, "/tf_set_mode_command")
+        self.tf_set_charge_mode_client_ = self.create_client(TFSetChargeModeCommand,
+                                                             "/tf_set_charge_mode_command")
+        self.tf_set_curr_lim_client_ = self.create_client(TFSetCurrLimCommand,
+                                                          "/tf_set_curr_lim_command")
+        self.tf_set_state_machine_client_ = self.create_client(TFSetStateMachineCommand,
+                                                               "/tf_set_state_machine_command")
+        self.tf_watch_dog_client_ = self.create_client(TFWatchDogCommand, "/tf_watch_dog_command")
+        self.tf_reset_client_ = self.create_client(TFResetCommand, "/tf_reset_command")
+
+        found = self.wait_for_service(self.pc_pack_rate_client_, "/pc_pack_rate_command")
+        found &= self.wait_for_service(self.pc_wind_curr_client_, "/pc_wind_curr_command")
+        found &= self.wait_for_service(self.bender_client_, "/bender_command")
+        found &= self.wait_for_service(self.bc_reset_client_, "/bc_reset_command")
+        found &= self.wait_for_service(self.pump_client_, "/pump_command")
+        found &= self.wait_for_service(self.valve_client_, "/valve_command")
+        found &= self.wait_for_service(self.tether_client_, "/tether_command")
+        found &= self.wait_for_service(self.sc_reset_client_, "/sc_reset_command")
+        found &= self.wait_for_service(self.sc_pack_rate_client_, "/sc_pack_rate_command")
+        found &= self.wait_for_service(self.pc_scale_client_, "/fake_pc_scale_command")
+        found &= self.wait_for_service(self.pc_retract_client_, "/pc_retract_command")
+        found &= self.wait_for_service(self.pc_v_targ_max_client_, "/pc_v_targ_max_command")
+        found &= self.wait_for_service(self.pc_charge_curr_lim_client_,
+                                       "/pc_charge_curr_lim_command")
+        found &= self.wait_for_service(self.pc_batt_switch_client_, "/pc_batt_switch_command")
+        found &= self.wait_for_service(self.gain_client_, "/gain_command")
+        found &= self.wait_for_service(self.pc_std_dev_targ_client_, "/pc_std_dev_targ_command")
+        found &= self.wait_for_service(self.pc_draw_curr_lim_client_, "/pc_draw_curr_lim_command")
+        found &= self.wait_for_service(self.pc_bias_curr_client_, "/pc_bias_curr_command")
+        found &= self.wait_for_service(self.tf_set_pos_client_, "/tf_set_pos_command")
+        found &= self.wait_for_service(self.tf_set_actual_pos_client_,
+                                       "/tf_set_actual_pos_command")
+        found &= self.wait_for_service(self.tf_set_mode_client_, "/tf_set_mode_command")
+        found &= self.wait_for_service(self.tf_set_charge_mode_client_,
+                                       "/tf_set_charge_mode_command")
+        found &= self.wait_for_service(self.tf_set_curr_lim_client_, "/tf_set_curr_lim_command")
+        found &= self.wait_for_service(self.tf_set_state_machine_client_,
+                                       "/tf_set_state_machine_command")
+        found &= self.wait_for_service(self.tf_watch_dog_client_, "/tf_watch_dog_command")
+        found &= self.wait_for_service(self.tf_reset_client_, "/tf_reset_command")
+
+        if not found:
+            self.get_logger().error("Did not find required services")
+            return
+
+        self.pc_pack_rate_future_ = None
+        self.pc_wind_curr_future_ = None
+        self.bender_future_ = None
+        self.bc_reset_future_ = None
+        self.pump_future_ = None
+        self.valve_future_ = None
+        self.tether_future_ = None
+        self.sc_reset_future_ = None
+        self.sc_pack_rate_future_ = None
+        self.pc_scale_future_ = None
+        self.pc_retract_future_ = None
+        self.pc_v_targ_max_future_ = None
+        self.pc_charge_curr_lim_future_ = None
+        self.pc_batt_switch_future_ = None
+        self.gain_future_ = None
+        self.pc_std_dev_targ_future_ = None
+        self.pc_draw_curr_lim_future_ = None
+        self.pc_bias_curr_future_ = None
+        self.tf_set_pos_future_ = None
+        self.tf_set_actual_pos_future_ = None
+        self.tf_set_mode_future_ = None
+        self.tf_set_charge_mode_future_ = None
+        self.tf_set_curr_lim_future_ = None
+        self.tf_set_state_machine_future_ = None
+        self.tf_watch_dog_future_ = None
+        self.tf_reset_future_ = None
+
+        self.setup_subscribers()
+
+    # if user has shadowed a callback in their user-derived class, this will use their
+    # implementation if they did not define one, the subscriber will not be set up
+    def setup_subscribers(self):
+        self.subs_ = []
+        sub_info = []
+        sub_info.append(["ahrs_callback", "/ahrs_data", XBRecord, self.ahrs_callback])
+        sub_info.append(["battery_callback", "/battery_data", BCRecord, self.battery_callback])
+        sub_info.append(["spring_callback", "/spring_data", SCRecord, self.spring_callback])
+        sub_info.append(["power_callback", "/power_data", PCRecord, self.power_callback])
+        sub_info.append(["trefoil_callback", "/trefoil_data", TFRecord, self.trefoil_callback])
+        sub_info.append(["powerbuoy_callback", "/powerbuoy_data",
+                         PBRecord, self.powerbuoy_callback])
+        for cb_name, topic, msg_type, cb in sub_info:
+            if cb_name in self.__class__.__dict__:  # did derived override a callback?
+                self.get_logger().info("Subscribing to XBRecord on '{topic}'".format(topic=topic))
+                sub = self.create_subscription(msg_type, topic, cb, 10)
+                self.subs_.append(sub)
+
+    # set publish rate of PC Microcontroller telemetry
+    def set_pc_pack_rate(self):
+        request = PCPackRateCommand.Request()
+        request.rate_hz = 50
+
+        self.pc_pack_rate_future_ = self.pc_pack_rate_client_.call_async(request)
+        self.pc_pack_rate_future_.add_done_callback(self.service_response_callback)
+
+    # set publish rate of SC Microcontroller telemetry
+    def set_sc_pack_rate(self):
+        request = SCPackRateCommand.Request()
+        request.rate_hz = 50
+
+        self.sc_pack_rate_future_ = self.sc_pack_rate_client_.call_async(request)
+        self.sc_pack_rate_future_.add_done_callback(self.service_response_callback)
+
+    # set_params and callbacks optionally defined by user
+    def set_params(self): pass
+    def ahrs_callback(self, data): pass
+    def battery_callback(self, data): pass
+    def spring_callback(self, data): pass
+    def power_callback(self, data): pass
+    def trefoil_callback(self, data): pass
+    def powerbuoy_callback(self, data): pass
+
+    # generic service callback
+    def service_response_callback(self, future):
+        resp = future.result()
+        if resp.result.value == resp.result.OK:
+            self.get_logger().info("Command Successful")
+        else:
+            self.get_logger().error(
+              "Command Failed: received error code [[ %s ]]",
+              pbsrv_enum2str[resp.result.value].c_str())
+            # TODO(andermi): should we shutdown?
+
+    def wait_for_service(self, client, service_name):
+        while not client.wait_for_service(timeout_sec=1.0):
+            if not rclpy.ok():
+                self.get_logger().error(
+                  "Interrupted while waiting for {sn}. Exiting.".format(sn=service_name))
+                return False
+
+            self.get_logger().info(
+              "{sn} not available, still waiting...".format(sn=service_name))
+        return True

--- a/buoy_msgs/interface.py
+++ b/buoy_msgs/interface.py
@@ -78,7 +78,7 @@ class Interface(Node):
         self.tether_client_ = self.create_client(TetherCommand, "/tether_command")
         self.sc_reset_client_ = self.create_client(SCResetCommand, "/sc_reset_command")
         self.sc_pack_rate_client_ = self.create_client(SCPackRateCommand, "/sc_pack_rate_command")
-        self.pc_scale_client_ = self.create_client(PCScaleCommand, "/fake_pc_scale_command")
+        self.pc_scale_client_ = self.create_client(PCScaleCommand, "/pc_scale_command")
         self.pc_retract_client_ = self.create_client(PCRetractCommand, "/pc_retract_command")
         self.pc_v_targ_max_client_ = self.create_client(PCVTargMaxCommand,
                                                         "/pc_v_targ_max_command")

--- a/buoy_msgs/interface.py
+++ b/buoy_msgs/interface.py
@@ -1,6 +1,6 @@
 # Copyright 2022 Open Source Robotics Foundation, Inc. and Monterey Bay Aquarium Research Institute
 #
-# Licensed under the Apache License, Version 2.0 (the "License")
+# Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 
 import rclpy
 from rclpy.node import Node

--- a/package.xml
+++ b/package.xml
@@ -8,8 +8,10 @@
   <license>TODO: License declaration</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
   
   <depend>rclcpp</depend>
+  <depend>rclpy</depend>
   
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>


### PR DESCRIPTION
usage example to follow in `buoy_examples`

passing `colcon test`

```
Label Time Summary:
copyright     =   0.55 sec*proc (1 test)
cppcheck      =   2.24 sec*proc (10 tests)
cpplint       =  23.14 sec*proc (10 tests)
flake8        =   0.75 sec*proc (2 tests)
lint_cmake    =   0.19 sec*proc (1 test)
linter        =  32.26 sec*proc (37 tests)
pep257        =   0.84 sec*proc (2 tests)
uncrustify    =   4.17 sec*proc (10 tests)
xmllint       =   0.39 sec*proc (1 test)
```