### PR TITLE
Setup CI

### DIFF
--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -16,9 +16,7 @@ curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key
 apt-get update -qq
 apt-get install -y git \
                    python3-colcon-common-extensions \
-                   python3-rosdep \
-                   python3-vcstool \
-                   wget
+                   python3-rosdep
 
 cd $COLCON_WS_SRC
 cp -r $GITHUB_WORKSPACE $COLCON_WS_SRC

--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -23,7 +23,7 @@ cp -r $GITHUB_WORKSPACE $COLCON_WS_SRC
 
 rosdep init
 rosdep update
-rosdep install --from-paths ./ -i -y -r --rosdistro $ROS_DISTRO
+rosdep install --from-paths $COLCON_WS_SRC -i -y --rosdistro $ROS_DISTRO
 
 # Build
 source /opt/ros/$ROS_DISTRO/setup.bash

--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -ev
+
+export COLCON_WS=~/ws
+export COLCON_WS_SRC=${COLCON_WS}/src
+export DEBIAN_FRONTEND=noninteractive
+export ROS_PYTHON_VERSION=3
+
+mkdir -p $COLCON_WS_SRC
+
+apt update -qq
+apt install -qq -y lsb-release wget curl build-essential
+
+echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list
+curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
+apt-get update -qq
+apt-get install -y git \
+                   python3-colcon-common-extensions \
+                   python3-rosdep \
+                   python3-vcstool \
+                   wget
+
+cd $COLCON_WS_SRC
+cp -r $GITHUB_WORKSPACE $COLCON_WS_SRC
+
+rosdep init
+rosdep update
+rosdep install --from-paths ./ -i -y -r --rosdistro $ROS_DISTRO
+
+# Build
+source /opt/ros/$ROS_DISTRO/setup.bash
+cd $COLCON_WS
+colcon build --event-handlers console_direct+
+
+# Test
+colcon test --event-handlers console_direct+
+colcon test-result

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: Build and test
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    name: Build and test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - gz-version: "fortress"
+            ros-distro: "galactic"
+    container:
+      image: ubuntu:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and Test
+        run: .github/workflows/build-and-test.sh
+        env:
+          IGNITION_VERSION: ${{ matrix.gz-version  }}
+          ROS_DISTRO: ${{ matrix.ros-distro }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - gz-version: "fortress"
-            ros-distro: "galactic"
+          - ros-distro: "galactic"
     container:
       image: ubuntu:latest
     steps:
@@ -19,5 +18,4 @@ jobs:
       - name: Build and Test
         run: .github/workflows/build-and-test.sh
         env:
-          IGNITION_VERSION: ${{ matrix.gz-version  }}
           ROS_DISTRO: ${{ matrix.ros-distro }}


### PR DESCRIPTION
Originally I thought we could rely on CI from `buoy_sim` (see https://github.com/osrf/buoy_sim/pull/7) to test this package until we release it on the ROS farm and can rely on CI from there. But now that this package has more than just messages and we're actively working on it, I think it's valuable to run some CI directly here.