### PR TITLE
Use standard messages for AHRS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,11 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclpy REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
@@ -48,7 +50,10 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/TFSetStateMachineCommand.srv"
   "srv/TFWatchDogCommand.srv"
   "srv/ValveCommand.srv"
-  DEPENDENCIES std_msgs
+  DEPENDENCIES
+    geometry_msgs
+    sensor_msgs
+    std_msgs
   ADD_LINTER_TESTS
 )
 

--- a/README.md
+++ b/README.md
@@ -10,31 +10,31 @@ Collection of telemetry (feedback) from buoy sensors and microcontrollers.
 ### Telemetry
 Telemetry data from sensors available per microcontroller
 
-- type: `BCRecord`  
-  topic: `/bc_record`  
+- type: `BCRecord`
+  topic: `/bc_record`
   Description: (TODO) battery data
-  
-- type: `PCRecord`  
-  topic: `/pc_record`  
+
+- type: `PCRecord`
+  topic: `/pc_record`
   Description: (TODO) power controller data
-  
-- type: `SCRecord`  
-  topic: `/sc_record`  
+
+- type: `SCRecord`
+  topic: `/sc_record`
   Description: (TODO) spring controller data
-  
-- type: `TFRecord`  
-  topic: `/tf_record`  
+
+- type: `TFRecord`
+  topic: `/tf_record`
   Description: (TODO) trefoil data
-  
-- type: `XBRecord`  
-  topic: `/xb_record`  
+
+- type: `XBRecord`
+  topic: `/xb_record`
   Description: (TODO) Crossbow AHRS data
 
 ### Consolidated (Time-Synchronized) Telemetry
 Snapshot in time of all data from the buoy.
 
-- type: `PBRecord`  
-  topic: `/pb_record`  
+- type: `PBRecord`
+  topic: `/pb_record`
   Description: TODO
 
 ## Services (.srv)
@@ -43,143 +43,143 @@ Collection of commands to configure/control the Power Buoy.
 ### Power Microcontroller
 Services available to configure the Power Microcontroller.
 
-- type: `PCBattSwitchCommand`  
-  topic: `/pc_batt_switch_command`  
-  args: OFF, ON (enum)  
+- type: `PCBattSwitchCommand`
+  topic: `/pc_batt_switch_command`
+  args: OFF, ON (enum)
   Description: TODO
-  
-- type: `PCBiasCurrCommand`  
-  topic: `/pc_bias_curr_command`  
-  args: -15.0 to +15.0 (float, amps)  
+
+- type: `PCBiasCurrCommand`
+  topic: `/pc_bias_curr_command`
+  args: -15.0 to +15.0 (float, amps)
   Description: TODO
-  
-- type: `PCChargeCurrLimCommand`  
-  topic: `/pc_charge_curr_lim_command`  
-  args: 2.0 to 12.0 (float, amps)  
+
+- type: `PCChargeCurrLimCommand`
+  topic: `/pc_charge_curr_lim_command`
+  args: 2.0 to 12.0 (float, amps)
   Description: TODO
-  
-- type: `PCDrawCurrLimCommand`  
-  topic: `/pc_draw_curr_lim_command`  
-  args: 2.0 to 12.0 (float, amps)  
+
+- type: `PCDrawCurrLimCommand`
+  topic: `/pc_draw_curr_lim_command`
+  args: 2.0 to 12.0 (float, amps)
   Description: TODO
-  
-- type: `PCPackRateCommand`  
-  topic: `/pc_pack_rate_command`  
-  args: 10 to 50 (int, hz)  
+
+- type: `PCPackRateCommand`
+  topic: `/pc_pack_rate_command`
+  args: 10 to 50 (int, hz)
   Description: set PCRecord publish rate in Hz
-  
-- type: `PCRetractCommand`  
-  topic: `/pc_retract_command`  
-  args: 0.4 to 1.0 (float)  
+
+- type: `PCRetractCommand`
+  topic: `/pc_retract_command`
+  args: 0.4 to 1.0 (float)
   Description: TODO
-  
-- type: `PCScaleCommand`  
-  topic: `/pc_scale_command`  
-  args: 0.5 to 1.4 (float)  
+
+- type: `PCScaleCommand`
+  topic: `/pc_scale_command`
+  args: 0.5 to 1.4 (float)
   Description: TODO
-  
-- type: `PCStdDevTargCommand`  
-  topic: `/pc_std_dev_targ_command`  
-  args: 0 to 2000 (int) 
+
+- type: `PCStdDevTargCommand`
+  topic: `/pc_std_dev_targ_command`
+  args: 0 to 2000 (int)
   Description: TODO
-  
-- type: `PCVTargMaxCommand`  
-  topic: `/pc_v_targ_max_command`  
-  args: 320.0 to 330.0 (float, volts)  
+
+- type: `PCVTargMaxCommand`
+  topic: `/pc_v_targ_max_command`
+  args: 320.0 to 330.0 (float, volts)
   Description: TODO
-  
-- type: `PCWindCurrCommand`  
-  topic: `/pc_wind_curr_command`  
-  args: -35.0 to 35.0 (float, amps)  
+
+- type: `PCWindCurrCommand`
+  topic: `/pc_wind_curr_command`
+  args: -35.0 to 35.0 (float, amps)
   Description: TODO
-  
-- type: `GainCommand`  
-  topic: `/gain_command`  
-  args: OFF, 1 to 200 (enum or int)  
+
+- type: `GainCommand`
+  topic: `/gain_command`
+  args: OFF, 1 to 200 (enum or int)
   Description: TODO
 
 ### Battery Microcontroller
 Services available to configure the Battery Microcontroller.
 
-- type: `BCResetCommand`  
-  topic: `/bc_reset_command`  
-  args: None  
+- type: `BCResetCommand`
+  topic: `/bc_reset_command`
+  args: None
   Description: TODO
 
 ### Spring Microcontroller
-- type: `SCPackRateCommand`  
-  topic: `/sc_pack_rate_command`  
-  args: 10 to 50 (int, hz)  
+- type: `SCPackRateCommand`
+  topic: `/sc_pack_rate_command`
+  args: 10 to 50 (int, hz)
   Description: set SCRecord publish rate in Hz
-  
-- type: `SCResetCommand`  
-  topic: `/sc_reset_command`  
-  args: None  
+
+- type: `SCResetCommand`
+  topic: `/sc_reset_command`
+  args: None
   Description: TODO
-  
-- type: `ValveCommand`  
-  topic: `/valve_command`  
-  args: OFF, 1 to 127 (enum or int, seconds)  
+
+- type: `ValveCommand`
+  topic: `/valve_command`
+  args: OFF, 1 to 127 (enum or int, seconds)
   Description: TODO
-  
-- type: `PumpCommand`  
-  topic: `/pump_command`  
-  args: OFF, 1 to 127 (enum or int, seconds)  
+
+- type: `PumpCommand`
+  topic: `/pump_command`
+  args: OFF, 1 to 127 (enum or int, seconds)
   Description: TODO
-  
-- type: `BenderCommand`  
-  topic: `/bender_command`  
-  args: OFF, ON, AUTO (enum)  
+
+- type: `BenderCommand`
+  topic: `/bender_command`
+  args: OFF, ON, AUTO (enum)
   Description: TODO
-  
-- type: `TetherCommand`  
-  topic: `/tether_command`  
-  args: OFF, ON (enum)  
+
+- type: `TetherCommand`
+  topic: `/tether_command`
+  args: OFF, ON (enum)
   Description: TODO
 
 ### Trefoil Microcontroller
 Services available to configure the Trefoil.
 
-- type: `TFResetCommand`  
-  topic: `/tf_reset_command`  
-  args: None  
+- type: `TFResetCommand`
+  topic: `/tf_reset_command`
+  args: None
   Description: TODO
-  
-- type: `TFSetActualPosCommand`  
-  topic: `/tf_set_actual_pos_command`  
-  args: OPEN, CLOSED (enum)  
+
+- type: `TFSetActualPosCommand`
+  topic: `/tf_set_actual_pos_command`
+  args: OPEN, CLOSED (enum)
   Description: TODO
-  
-- type: `TFSetChargeModeCommand`  
-  topic: `/tf_set_charge_mode_command`  
-  args: OFF, ON, AUTO_TIME, AUTO_VOLTAGE (enum)  
+
+- type: `TFSetChargeModeCommand`
+  topic: `/tf_set_charge_mode_command`
+  args: OFF, ON, AUTO_TIME, AUTO_VOLTAGE (enum)
   Description: TODO
-  
-- type: `TFSetCurrLimCommand`  
-  topic: `/tf_set_curr_lim_command`  
-  args: 500 to 5000 (int, TODO(units))  
+
+- type: `TFSetCurrLimCommand`
+  topic: `/tf_set_curr_lim_command`
+  args: 500 to 5000 (int, TODO(units))
   Description: TODO
-  
-- type: `TFSetModeCommand`  
-  topic: `/tf_set_mode_command`  
-  args: POWER_10W, MONITOR_POS, HOLD_POS (enum)  
+
+- type: `TFSetModeCommand`
+  topic: `/tf_set_mode_command`
+  args: POWER_10W, MONITOR_POS, HOLD_POS (enum)
   Description: TODO
-  
-- type: `TFSetPosCommand`  
-  topic: `/tf_set_pos_command`  
-  args: OPEN, CLOSED (enum)  
+
+- type: `TFSetPosCommand`
+  topic: `/tf_set_pos_command`
+  args: OPEN, CLOSED (enum)
   Description: TODO
-  
-- type: `TFSetStateMachineCommand`  
-  topic: `/tf_set_state_machine_command`  
-  args: HOME_MOVE, VEL_MOVE (enum)  
+
+- type: `TFSetStateMachineCommand`
+  topic: `/tf_set_state_machine_command`
+  args: HOME_MOVE, VEL_MOVE (enum)
   Description: TODO
-  
-- type: `TFWatchDogCommand`  
-  topic: `/tf_watchdog_command`  
-  args: None  
+
+- type: `TFWatchDogCommand`
+  topic: `/tf_watchdog_command`
+  args: None
   Description: TODO
-  
+
 
 ## Quality Declaration
 

--- a/msg/XBRecord.msg
+++ b/msg/XBRecord.msg
@@ -1,26 +1,20 @@
-#Crossbow AHRS
+# Crossbow AHRS
 
-std_msgs/Header header  # timestamp, seq_num
+# Timestamp, seq_num
+std_msgs/Header header
 
-float32 roll_angle  # Radians -pi to +pi
-float32 pitch_angle  # Radians -pi to +pi
-float32 yaw_angle_true  # (true north) Radians -pi to +pi
+# IMU data
+# * orientation expressed as a quaternion (radians)
+# * angular velocity (rad/s)
+# * linear acceleration (m/s^2, not in g)
+sensor_msgs/Imu imu
 
-float32 x_rate_corrected  # Corrected X angular rate, rads/sec
-float32 y_rate_corrected  # Corrected Y angular rate, rads/sec
-float32 z_rate_corrected  # Corrected Z angular rate, rads/sec
+# GPS latitude, longitude, altitude
+sensor_msgs/NavSatFix gps
 
-float32 x_accel  # X accelerometer, g
-float32 y_accel  # Y accelerometer, g
-float32 z_accel  # Z accelerometer, g
+# Linear velocity expressed in North-East-Down frame, in m/s
+geometry_msgs/Vector3 ned_velocity
 
-float32 n_velocity  # North velocity, m/s
-float32 e_velocity  # East  velocity, m/s
-float32 d_velocity  # Down  velocity, m/s
-
-float32 longitude  # GPS longitude, radians
-float32 latitude  # GPS latitude,  radians
-float32 altitude  # GPS altitude,  meters (-100 to 16284)
-
-float32 x_rate_temp  # X rate temperature, C
+# X rate temperature, C
+float32 x_rate_temp
 

--- a/msg/XBRecord.msg
+++ b/msg/XBRecord.msg
@@ -16,5 +16,4 @@ sensor_msgs/NavSatFix gps
 geometry_msgs/Vector3 ned_velocity
 
 # X rate temperature, C
-float32 x_rate_temp
-
+sensor_msgs/Temperature x_rate_temp

--- a/package.xml
+++ b/package.xml
@@ -9,14 +9,16 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
-  
+
   <depend>rclcpp</depend>
   <depend>rclpy</depend>
-  
+
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
-  <exec_depend>std_msgs</exec_depend>
+  <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
* Part of #6 

I didn't find a standard representation for data coming from an AHRS sensor, so here's a first draft for how we could use some messages from `common_interfaces`. 

I'm not sure about the frame of reference for the IMU values, it would be good to document them.

Another thing to consider is to break this message apart and publish each standard message on a separate topic. The advantage of that is to have immediate access to all the existing tooling around the standard messages, like visualizing IMU data on RViz, plotting lat/lon to a map, and so on.

Let me know what you think, @andermi !

---

This is the mapping from the previous fields to the new ones:

Before | After
-- | --
`header` | `header` (no change}
`roll_angle`, `pitch_angle` `yaw_angle_true` | [sensor_msgs/Imu](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/Imu.msg): `imu.orientation` (this is a quaternion, not RPY)
`x_rate_corrected` | [sensor_msgs/Imu](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/Imu.msg): `imu.angular_velocity.x` (stays as rad/s)
`y_rate_corrected` | [sensor_msgs/Imu](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/Imu.msg): `imu.angular_velocity.y` (stays as rad/s)
`z_rate_corrected` | [sensor_msgs/Imu](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/Imu.msg): `imu.angular_velocity.z` (stays as rad/s)
`x_accel` | [sensor_msgs/Imu](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/Imu.msg): `imu.linear_acceleration,x` (the message documentation recommends m/s^2 instead of g)
`y_accel`| [sensor_msgs/Imu](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/Imu.msg): `imu.linear_acceleration.y` (the message documentation recommends m/s^2 instead of g)
`z_accel` | [sensor_msgs/Imu](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/Imu.msg): `imu.linear_acceleration.z` (the message documentation recommends m/s^2 instead of g)
`n_velocity` | [geometry_msgs/Vector3](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/msg/Vector3.msg): `ned_velocity.x`
`e_velocity` | [geometry_msgs/Vector3](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/msg/Vector3.msg): `ned_velocity.y`
`d_velocity` | [geometry_msgs/Vector3](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/msg/Vector3.msg): `ned_velocity.z`
`latitude` | [sensor_msgs/NavSatFix](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/NavSatFix.msg): `gps.latitude`
`longitude` | [sensor_msgs/NavSatFix](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/NavSatFix.msg): `gps.longitude`
`altitude` | [sensor_msgs/NavSatFix](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/NavSatFix.msg): `gps.altitude`
`x_rate_temp` | [sensor_msgs/Temperature](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/Temperature.msg): `x_rate_temp.temperature` (still in Celsius)
