### PR TITLE
Use standard messages within TFRecord

### DIFF
--- a/msg/TFRecord.msg
+++ b/msg/TFRecord.msg
@@ -6,12 +6,23 @@ int32 power_timeouts
 float32 tether_voltage
 float32 battery_voltage
 float32 pressure
-float32[4] qtn
-float32[3] mag  # gauss
+
+# Quaternion in meters
+geometry_msgs/Quaternion qtn
+
+# Magnetic field in Tesla
+sensor_msgs/MagneticField mag
+
 int16 status  # bit field
-float32[3] ang_rate  # rad/sec
+
+# Angular velocity in rad/s
+geometry_msgs/Vector3 ang_rate
+
 int16 vpe_status  # bit field
-float32[3] accel  # m/sec^2
+
+# Linear acceleration m/s^2
+geometry_msgs/Vector3 accel
+
 int32 comms_timeouts
 int32 motor_status  # Maxon status
 int32 motor_current  # motor current

--- a/msg/TFRecord.msg
+++ b/msg/TFRecord.msg
@@ -7,21 +7,15 @@ float32 tether_voltage
 float32 battery_voltage
 float32 pressure
 
-# Quaternion in meters
-geometry_msgs/Quaternion qtn
+# IMU containing orientation, angular velocity and linear acceleration
+sensor_msgs/Imu imu
 
 # Magnetic field in Tesla
 sensor_msgs/MagneticField mag
 
 int16 status  # bit field
 
-# Angular velocity in rad/s
-geometry_msgs/Vector3 ang_rate
-
 int16 vpe_status  # bit field
-
-# Linear acceleration m/s^2
-geometry_msgs/Vector3 accel
 
 int32 comms_timeouts
 int32 motor_status  # Maxon status


### PR DESCRIPTION
* Part of #6 

I only updated a few of the fields that looked reasonably equivalent to some standard messages.

This is the mapping from the previous fields to the new ones. Most of them should be straight-forward.

## As of [eca2099](https://github.com/osrf/buoy_msgs/pull/9/commits/eca20995d984282475ec57c93d72366e281593e1)

Before | After
-- | --
`float32[4] qtn` | `geometry_msgs/Quaternion qtn`
`float32[3] mag` | [sensor_msgs/MagneticField mag](http://docs.ros.org/en/lunar/api/sensor_msgs/html/msg/MagneticField.html) - note that ROS uses SI, so the units should be Tesla instead of Gauss
`float32[3] ang_rate` | `geometry_msgs/Vector3 ang_rate`
`float32[3] accel` | `geometry_msgs/Vector3 accel`

## New

Before | After
-- | --
`float32[4] qtn` | `sensor_msgs/Imu imu` - `imu.orientation`
`float32[3] mag` | [sensor_msgs/MagneticField mag](http://docs.ros.org/en/lunar/api/sensor_msgs/html/msg/MagneticField.html) - note that ROS uses SI, so the units should be Tesla instead of Gauss
`float32[3] ang_rate` |  `sensor_msgs/Imu imu` - `imu.angular_velocity`
`float32[3] accel` |  `sensor_msgs/Imu imu` - `imu.linear_acceleration`