### PR TITLE
Install flake8 plugins for testing 

### DIFF
--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -11,7 +11,7 @@ mkdir -p $COLCON_WS_SRC
 apt update -qq
 apt install -qq -y lsb-release wget curl build-essential
 
-echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list
+echo "deb http://packages.ros.org/ros2-testing/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-testing.list
 curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
 apt-get update -qq
 apt-get install -y build-essential \

--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -14,16 +14,15 @@ apt install -qq -y lsb-release wget curl build-essential
 echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list
 curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
 apt-get update -qq
-apt-get install -y git \
-                   python3-colcon-common-extensions \
-                   python3-rosdep
-                   build-essential \
+apt-get install -y build-essential \
                    cmake \
                    git \
+                   python3-colcon-common-extensions \
                    python3-colcon-common-extensions \
                    python3-flake8 \
                    python3-pip \
                    python3-pytest-cov \
+                   python3-rosdep \
                    python3-rosdep \
                    python3-setuptools \
                    python3-vcstool \

--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -17,8 +17,18 @@ apt-get update -qq
 apt-get install -y git \
                    python3-colcon-common-extensions \
                    python3-rosdep
-
-# Python packages needed for testing
+                   build-essential \
+                   cmake \
+                   git \
+                   python3-colcon-common-extensions \
+                   python3-flake8 \
+                   python3-pip \
+                   python3-pytest-cov \
+                   python3-rosdep \
+                   python3-setuptools \
+                   python3-vcstool \
+                   wget
+# TODO: get from apt when upgrading to Jammy
 python3 -m pip install -U \
   flake8-blind-except \
   flake8-builtins \

--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -18,6 +18,21 @@ apt-get install -y git \
                    python3-colcon-common-extensions \
                    python3-rosdep
 
+# Python packages needed for testing
+python3 -m pip install -U \
+  flake8-blind-except \
+  flake8-builtins \
+  flake8-class-newline \
+  flake8-comprehensions \
+  flake8-deprecated \
+  flake8-docstrings \
+  flake8-import-order \
+  flake8-quotes \
+  pytest-repeat \
+  pytest-rerunfailures \
+  pytest \
+  setuptools
+
 cd $COLCON_WS_SRC
 cp -r $GITHUB_WORKSPACE $COLCON_WS_SRC
 


### PR DESCRIPTION
Both CI and me locally were missing these extra plugins for testing, listed here: https://docs.ros.org/en/galactic/Installation/Alternatives/Ubuntu-Development-Setup.html#install-development-tools-and-ros-tools

Kudos to @andermi for actually following the official installation instructions 😄 