### PR TITLE
splinter_ros: add missing include

### DIFF
--- a/splinter_ros/src/splinter1d.cpp
+++ b/splinter_ros/src/splinter1d.cpp
@@ -21,6 +21,7 @@
 #include <SPLINTER/utilities.h>
 
 #include <algorithm>
+#include <iostream>
 #include <memory>
 #include <vector>
 

--- a/splinter_ros/src/splinter2d.cpp
+++ b/splinter_ros/src/splinter2d.cpp
@@ -21,6 +21,7 @@
 #include <SPLINTER/utilities.h>
 
 #include <algorithm>
+#include <iostream>
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
Add missing include for `<iostream>`.  Fixes a compile error (on macOS / clang).