### PR TITLE
development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # mbari_wec_utils
 
-Packages in this repo provide interfaces, API, examples for [MBARI WEC](https://github.com/osrf/mbari_wec/tree/main).
+Packages in this repo provide interfaces, API, examples for [MBARI WEC](https://github.com/osrf/mbari_wec/tree/dev).
 
 Documentation on API, messages, and services may be found here:  
-[Python API](https://osrf.github.io/mbari_wec/main/ROS2/python_api/)  
-[C++ API](https://osrf.github.io/mbari_wec/main/ROS2/cpp_api/)  
-[ROS 2 Interfaces](https://osrf.github.io/mbari_wec/main/ROS2/messages/)
+[Python API](https://osrf.github.io/mbari_wec/dev/ROS2/python_api/)  
+[C++ API](https://osrf.github.io/mbari_wec/dev/ROS2/cpp_api/)  
+[ROS 2 Interfaces](https://osrf.github.io/mbari_wec/dev/ROS2/messages/)
 
 Complete examples starting from template repositories may be found here:  
 [Python linear damper](https://github.com/mbari-org/mbari_wec_template_py/tree/linear_damper_example)  
 [C++ linear damper](https://github.com/mbari-org/mbari_wec_template_cpp/tree/linear_damper_example)
 
-And tutorials may be found [here](https://osrf.github.io/mbari_wec/main/tutorials).
+And tutorials may be found [here](https://osrf.github.io/mbari_wec/dev/tutorials).
 
 For more information about ROS 2 interfaces, see [docs.ros.org](https://docs.ros.org/en/rolling/Concepts/About-ROS-Interfaces.html).
 

--- a/buoy_api_cpp/QUALITY_DECLARATION.md
+++ b/buoy_api_cpp/QUALITY_DECLARATION.md
@@ -87,7 +87,7 @@ There are no currently copyrighted source files in this package.
 ### Direct Runtime ROS Dependencies [5.i]/[5.ii]
 
 `buoy_api_cpp` has the following runtime ROS dependencies, which are at **Quality Level 5**:
-* `buoy_interfaces` [QUALITY DECLARATION](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_interfaces/QUALITY_DECLARATION.md)
+* `buoy_interfaces` [QUALITY DECLARATION](https://github.com/osrf/mbari_wec_utils/tree/dev/buoy_interfaces/QUALITY_DECLARATION.md)
 
 It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
 

--- a/buoy_api_py/QUALITY_DECLARATION.md
+++ b/buoy_api_py/QUALITY_DECLARATION.md
@@ -87,7 +87,7 @@ There are no currently copyrighted source files in this package.
 ### Direct Runtime ROS Dependencies [5.i]/[5.ii]
 
 `buoy_api_py` has the following runtime ROS dependencies, which are at **Quality Level 5**:
-* `buoy_interfaces` [QUALITY DECLARATION](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_interfaces/QUALITY_DECLARATION.md)
+* `buoy_interfaces` [QUALITY DECLARATION](https://github.com/osrf/mbari_wec_utils/tree/dev/buoy_interfaces/QUALITY_DECLARATION.md)
 
 It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
 

--- a/buoy_api_py/buoy_api/interface.py
+++ b/buoy_api_py/buoy_api/interface.py
@@ -310,7 +310,7 @@ class Interface(Node):
                     pass
             self.get_logger().info('Found all required services.')
 
-    def spin(self):
+    def spin(self, sys_exit=False):
         """
         Set up a `MultiThreadedExecutor` and spin the node (blocking).
 
@@ -320,7 +320,21 @@ class Interface(Node):
         """
         executor = MultiThreadedExecutor()
         executor.add_node(self)
-        executor.spin()
+        try:
+            executor.spin()
+        except KeyboardInterrupt:
+            if rclpy.ok():
+                self.get_logger().info('Shutting down (SIGINT)...')
+            else:
+                print(f'[{self.get_name()}] Shutting down (SIGINT)...')
+        finally:
+            executor.remove_node(self)
+            self.destroy_node()
+            if exit:
+                if rclpy.ok():
+                    rclpy.shutdown()
+                import sys
+                sys.exit(0)
 
     def wait_for_services(self):
         # TODO(andermi)

--- a/pbcmd/QUALITY_DECLARATION.md
+++ b/pbcmd/QUALITY_DECLARATION.md
@@ -87,7 +87,7 @@ There are no currently copyrighted source files in this package.
 ### Direct Runtime ROS Dependencies [5.i]/[5.ii]
 
 `pbcmd` has the following runtime ROS dependencies, which are at **Quality Level 5**:
-* `buoy_interfaces` [QUALITY DECLARATION](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_interfaces/QUALITY_DECLARATION.md)
+* `buoy_interfaces` [QUALITY DECLARATION](https://github.com/osrf/mbari_wec_utils/tree/dev/buoy_interfaces/QUALITY_DECLARATION.md)
 
 It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
 

--- a/sim_pblog/README.md
+++ b/sim_pblog/README.md
@@ -1,7 +1,7 @@
 # sim_pblog
 Python app simulates MBARI's wave energy conversion buoy Logger function using ROS2 topics.
 
-Please see [buoy_msgs/buoy_api_py](https://github.com/osrf/buoy_msgs/tree/main/buoy_api_py)
-for controller [examples](https://github.com/osrf/buoy_msgs/tree/main/buoy_api_py/buoy_api/examples)
+Please see [buoy_msgs/buoy_api_py](https://github.com/osrf/buoy_msgs/tree/dev/buoy_api_py)
+for controller [examples](https://github.com/osrf/buoy_msgs/tree/dev/buoy_api_py/buoy_api/examples)
 
 ## Modified template for python ROS2-enabled controller simulators

--- a/sim_pblog/sim_pblog/sim_pblog.py
+++ b/sim_pblog/sim_pblog/sim_pblog.py
@@ -404,11 +404,7 @@ def main():
     rclpy.init(args=extras)
     pblog = WECLogger(args.loghome if args.loghome else loghome_arg.default,
                       args.logdir if args.logdir else logdir_arg.default)
-    import time
-    while rclpy.ok():
-        rclpy.spin_once(pblog)
-        time.sleep(1./1000.)
-    rclpy.shutdown()
+    pblog.spin(sys_exit=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The goal is to leave main in the latest known good state and insulate it from continued, unstable development in the dev branch. New feature branches will branch from and merge to dev rather than main (in most cases). For a new release, dev will be merged to main and a release will be published from main as before.

Also, there is now a dev version of the documentation at: https://osrf.github.io/mbari_wec/dev/

NOTE: Remember to put dev branch references back to main before merging!