### PR TITLE
Make sim pblog shutdown gracefully

### DIFF
--- a/buoy_api_py/buoy_api/interface.py
+++ b/buoy_api_py/buoy_api/interface.py
@@ -310,7 +310,7 @@ class Interface(Node):
                     pass
             self.get_logger().info('Found all required services.')
 
-    def spin(self, exit=False):
+    def spin(self, sys_exit=False):
         """
         Set up a `MultiThreadedExecutor` and spin the node (blocking).
 
@@ -323,14 +323,18 @@ class Interface(Node):
         try:
             executor.spin()
         except KeyboardInterrupt:
-            if rclpy.ok(): self.get_logger().info('Shutting down (SIGINT)...')
-            else: print(f'[{self.get_name()}] Shutting down (SIGINT)...')
+            if rclpy.ok():
+                self.get_logger().info('Shutting down (SIGINT)...')
+            else:
+                print(f'[{self.get_name()}] Shutting down (SIGINT)...')
         finally:
             executor.remove_node(self)
             self.destroy_node()
             if exit:
-                if rclpy.ok(): rclpy.shutdown()
-                import sys; sys.exit(0)
+                if rclpy.ok():
+                    rclpy.shutdown()
+                import sys
+                sys.exit(0)
 
     def wait_for_services(self):
         # TODO(andermi)

--- a/buoy_api_py/buoy_api/interface.py
+++ b/buoy_api_py/buoy_api/interface.py
@@ -310,7 +310,7 @@ class Interface(Node):
                     pass
             self.get_logger().info('Found all required services.')
 
-    def spin(self):
+    def spin(self, exit=False):
         """
         Set up a `MultiThreadedExecutor` and spin the node (blocking).
 
@@ -320,7 +320,17 @@ class Interface(Node):
         """
         executor = MultiThreadedExecutor()
         executor.add_node(self)
-        executor.spin()
+        try:
+            executor.spin()
+        except KeyboardInterrupt:
+            if rclpy.ok(): self.get_logger().info('Shutting down (SIGINT)...')
+            else: print(f'[{self.get_name()}] Shutting down (SIGINT)...')
+        finally:
+            executor.remove_node(self)
+            self.destroy_node()
+            if exit:
+                if rclpy.ok(): rclpy.shutdown()
+                import sys; sys.exit(0)
 
     def wait_for_services(self):
         # TODO(andermi)

--- a/sim_pblog/sim_pblog/sim_pblog.py
+++ b/sim_pblog/sim_pblog/sim_pblog.py
@@ -404,11 +404,7 @@ def main():
     rclpy.init(args=extras)
     pblog = WECLogger(args.loghome if args.loghome else loghome_arg.default,
                       args.logdir if args.logdir else logdir_arg.default)
-    import time
-    while rclpy.ok():
-        rclpy.spin_once(pblog)
-        time.sleep(1./1000.)
-    rclpy.shutdown()
+    pblog.spin(exit=True)
 
 
 if __name__ == '__main__':

--- a/sim_pblog/sim_pblog/sim_pblog.py
+++ b/sim_pblog/sim_pblog/sim_pblog.py
@@ -404,7 +404,7 @@ def main():
     rclpy.init(args=extras)
     pblog = WECLogger(args.loghome if args.loghome else loghome_arg.default,
                       args.logdir if args.logdir else logdir_arg.default)
-    pblog.spin(exit=True)
+    pblog.spin(sys_exit=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This was bugging me ;-p and isn't actually an error...

Before:

```
[gazebo-1] [INFO] [1758566944.225722422] [rclcpp]: signal_handler(signum=2)
[INFO] [gazebo-1]: process has finished cleanly [pid 966942]
[INFO] [launch]: process[gazebo-1] was required: shutting down launched system
[INFO] [sim_pblog-3]: sending signal 'SIGINT' to process[sim_pblog-3]
[INFO] [parameter_bridge-2]: sending signal 'SIGINT' to process[parameter_bridge-2]
[sim_pblog-3] Traceback (most recent call last):
[sim_pblog-3]   File "/home/anderson/wec/igngzb/openrobotics/workspace/install/sim_pblog/lib/sim_pblog/sim_pblog", line 33, in <module>
[sim_pblog-3]     sys.exit(load_entry_point('sim-pblog==0.0.0', 'console_scripts', 'sim_pblog')())
[sim_pblog-3]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[parameter_bridge-2] [INFO] [1758566944.654985153] [rclcpp]: signal_handler(signum=2)
[sim_pblog-3]   File "/home/anderson/wec/igngzb/openrobotics/workspace/install/sim_pblog/lib/python3.12/site-packages/sim_pblog/sim_pblog.py", line 409, in main
[sim_pblog-3]     rclpy.spin_once(pblog)
[sim_pblog-3]   File "/opt/ros/jazzy/lib/python3.12/site-packages/rclpy/__init__.py", line 226, in spin_once
[sim_pblog-3]     executor.spin_once(timeout_sec=timeout_sec)
[sim_pblog-3]   File "/opt/ros/jazzy/lib/python3.12/site-packages/rclpy/executors.py", line 839, in spin_once
[sim_pblog-3]     self._spin_once_impl(timeout_sec)
[sim_pblog-3]   File "/opt/ros/jazzy/lib/python3.12/site-packages/rclpy/executors.py", line 823, in _spin_once_impl
[sim_pblog-3]     handler, entity, node = self.wait_for_ready_callbacks(
[sim_pblog-3]                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[sim_pblog-3]   File "/opt/ros/jazzy/lib/python3.12/site-packages/rclpy/executors.py", line 793, in wait_for_ready_callbacks
[sim_pblog-3]     return next(self._cb_iter)
[sim_pblog-3]            ^^^^^^^^^^^^^^^^^^^
[sim_pblog-3]   File "/opt/ros/jazzy/lib/python3.12/site-packages/rclpy/executors.py", line 697, in _wait_for_ready_callbacks
[sim_pblog-3]     wait_set.wait(timeout_nsec)
[sim_pblog-3] KeyboardInterrupt
[INFO] [parameter_bridge-2]: process has finished cleanly [pid 966943]
[ERROR] [sim_pblog-3]: process has died [pid 966944, exit code -2, cmd '/home/anderson/wec/igngzb/openrobotics/workspace/install/sim_pblog/lib/sim_pblog/sim_pblog --loghome /home/anderson/.pblogs --logdir --ros-args -r __node:=sim_pblog --params-file /home/anderson/wec/igngzb/openrobotics/workspace/install/sim_pblog/share/sim_pblog/config/sim_pblog.yaml'].
```

After:
```
[gazebo-1] [INFO] [1758568219.200409452] [rclcpp]: signal_handler(signum=2)
[INFO] [gazebo-1]: process has finished cleanly [pid 973198]
[INFO] [launch]: process[gazebo-1] was required: shutting down launched system
[INFO] [sim_pblog-3]: sending signal 'SIGINT' to process[sim_pblog-3]
[INFO] [parameter_bridge-2]: sending signal 'SIGINT' to process[parameter_bridge-2]
[parameter_bridge-2] [INFO] [1758568219.529937738] [rclcpp]: signal_handler(signum=2)
[INFO] [parameter_bridge-2]: process has finished cleanly [pid 973199]
[INFO] [sim_pblog-3]: process has finished cleanly [pid 973201]
```
